### PR TITLE
ignore those .aux files I am seeing in theories/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *.coq
 doc/*
 .DS_Store
+*.aux


### PR DESCRIPTION
I have actually no idea why Coq creates them. All I did is "make" in "theories/" with 8.5-rc1. But anyways, let's just ignore them...
