### PR TITLE
A few extra lemmas.

### DIFF
--- a/theories/Autosubst_Basics.v
+++ b/theories/Autosubst_Basics.v
@@ -221,7 +221,7 @@ Fixpoint take {X : Type} n (sigma : nat -> X) : list X :=
 Lemma id_comp {A B} (f : A -> B) : id >>> f = f. reflexivity. Qed.
 Lemma comp_id {A B} (f : A -> B) : f >>> id = f. reflexivity. Qed.
 Lemma compA {A B C D} (f : A -> B) (g : B -> C) (h : C -> D) :
-  (f >>> g) >>> h = f >>> (g >>> h).
+  f >>> (g >>> h) = (f >>> g) >>> h.
 Proof. reflexivity. Qed.
 
 Section LemmasForFun.

--- a/theories/Autosubst_Basics.v
+++ b/theories/Autosubst_Basics.v
@@ -314,6 +314,14 @@ Proof.
   rewrite !iterate_S, <- IHn. reflexivity.
 Qed.
 
+Lemma iterate_iterate {A} (f : A -> A) i j x :
+  iterate f i (iterate f j x) = iterate f (i + j) x.
+Proof.
+  induction i; intros.
+  { now rewrite iterate_0. }
+  { now rewrite plusSn, iterate_S, IHi. }
+Qed.
+
 Lemma equal_f {X Y} {f g : X -> Y} a : f = g -> f a = g a.
 Proof. intros. now subst. Qed.
 

--- a/theories/Autosubst_Lemmas.v
+++ b/theories/Autosubst_Lemmas.v
@@ -53,6 +53,11 @@ Proof.
   intros H. apply lift_inj in H. auto.
 Qed.
 
+Lemma lift_injn_eq (A B : term) n : A.[ren(+n)] = B.[ren(+n)] <-> A = B.
+Proof.
+  split; intros; subst; eauto using lift_injn.
+Qed.
+
 End SubstLemmas.
 
 (* Local Variables: *)

--- a/theories/Autosubst_Lemmas.v
+++ b/theories/Autosubst_Lemmas.v
@@ -32,6 +32,9 @@ Lemma up_comp_n sigma tau n :
   upn n sigma >> upn n tau = upn n (sigma >> tau).
 Proof. induction n; [reflexivity|now rewrite !iterate_S, <- IHn, up_comp]. Qed.
 
+Lemma upn_upn i j sigma : upn i (upn j sigma) = upn (i + j) sigma.
+Proof. eapply iterate_iterate. Qed.
+
 Lemma ren_uncomp A xi zeta : A.[ren (xi >>> zeta)] = A.[ren xi].[ren zeta].
 Proof. autosubst. Qed.
 

--- a/theories/Autosubst_Tactics.v
+++ b/theories/Autosubst_Tactics.v
@@ -22,7 +22,7 @@ Proof. f_ext. apply id_subst. Qed.
 
 Lemma id_scompR {A} sigma (f : _ -> A) :
   ids >>> (subst sigma >>> f) = sigma >>> f.
-Proof. now rewrite <- compA, id_scompX. Qed.
+Proof. now rewrite compA, id_scompX. Qed.
 
 Lemma subst_idX : subst ids = id.
 Proof. f_ext. exact subst_id. Qed.
@@ -112,7 +112,7 @@ Proof. f_ext. apply id_hsubst. Qed.
 
 Lemma id_hsubstR {A} (f : _ -> A) (sigma : var -> inner) :
   ids >>> (hsubst sigma >>> f) = ids >>> f.
-Proof. now rewrite <- compA, id_hsubstX. Qed.
+Proof. now rewrite compA, id_hsubstX. Qed.
 
 Lemma hsubst_idX : hsubst ids = id.
 Proof. f_ext. exact hsubst_id. Qed.
@@ -140,7 +140,7 @@ Proof. f_ext. apply subst_hsubst_comp. Qed.
 Lemma scomp_hcompR {A} sigma theta (f : _ -> A) :
   subst sigma >>> (hsubst theta >>> f) =
   hsubst theta >>> (subst (sigma >>> hsubst theta) >>> f).
-Proof. now rewrite <- compA, scomp_hcompX. Qed.
+Proof. now rewrite compA, scomp_hcompX. Qed.
 
 End LemmasForHSubst.
 

--- a/theories/Autosubst_Tactics.v
+++ b/theories/Autosubst_Tactics.v
@@ -39,6 +39,10 @@ Lemma subst_compR {A} sigma tau (f : _ -> A) :
   subst sigma >>> (subst tau >>> f) = subst (sigma >>> subst tau) >>> f.
 Proof. now rewrite <- subst_compX. Qed.
 
+Lemma scompA f g h :
+  f >> (g >> h) = f >> g >> h.
+Proof. unfold scomp. now rewrite <- subst_compX, compA. Qed.
+
 Lemma fold_ren_cons (x : var) (xi : var -> var) :
   ids x .: ren xi = ren (x .: xi).
 Proof. unfold ren. now rewrite scons_comp. Qed.


### PR DESCRIPTION
Hello,

I am experimenting with Autosubst, for use in teaching the metatheory of programming languages. Congratulations! My initial experiments are encouraging: life with de Bruijn indices is becoming tolerable.

I find that there are some situations where the tactics "asimpl" and "autosubst" are not sufficient and one has to explicitly establish auxiliary lemmas and use them as rewriting rules. Would you be interested in adding these lemmas to the library, provided they are of sufficient general interest? (Maybe I should ask also, is the library still maintained?)

For now, I am submitting a couple patches related to associativity, but I have more, if you are interested. (I could also show you the small project where I am using Autosubst.)

Best regards,
François Pottier.
