### PR TITLE
fix Coq 8.10 warnings and build examples on CI

### DIFF
--- a/.github/workflows/coq-ci.yml
+++ b/.github/workflows/coq-ci.yml
@@ -19,7 +19,6 @@ jobs:
           - 'coqorg/coq:8.12'
           - 'coqorg/coq:8.11'
           - 'coqorg/coq:8.10'
-          - 'coqorg/coq:8.9'
       fail-fast: false
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/coq-ci.yml
+++ b/.github/workflows/coq-ci.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: coq-community/docker-coq-action@v1
         with:
-          opam_file: 'coq-autosubst.opam'
+          opam_file: 'coq-autosubst-ci.opam'
           custom_image: ${{ matrix.image }}
 
 # See also:

--- a/Makefile
+++ b/Makefile
@@ -22,10 +22,10 @@ lib:
 
 all: lib examples-plain examples-ssr
 
-examples-plain:
+examples-plain: lib
 	$(MAKE) -C examples/plain
 
-examples-ssr:
+examples-ssr: lib
 	$(MAKE) -C examples/ssr
 
 clean-doc:

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ git remote set-url origin https://github.com/coq-community/autosubst.git
 
 ## Requirements
 
-- Coq 8.9 - 8.12
+- Coq 8.10 - 8.12
 - to compile `examples/ssr`, ssreflect is needed; version 1.7 appears to work
 
 ## Installation

--- a/coq-autosubst-ci.opam
+++ b/coq-autosubst-ci.opam
@@ -1,0 +1,14 @@
+opam-version: "2.0"
+maintainer: "palmskog@gmail.com"
+version: "dev"
+
+homepage: "https://github.com/coq-community/autosubst"
+dev-repo: "git+https://github.com/coq-community/autosubst.git"
+bug-reports: "https://github.com/coq-community/autosubst/issues"
+license: "MIT"
+
+synopsis: "Autosubst (CI only)"
+
+build: [make "-j%{jobs}%" "examples-plain"]
+install: []
+depends: ["coq"]

--- a/coq-autosubst.opam
+++ b/coq-autosubst.opam
@@ -20,7 +20,7 @@ substitutions."""
 build: [make "-j%{jobs}%" ]
 install: [make "install"]
 depends: [
-  "coq" {(>= "8.9" & < "8.14~") | (= "dev")}
+  "coq" {(>= "8.10" & < "8.14~") | (= "dev")}
 ]
 
 tags: [

--- a/theories/Autosubst_Basics.v
+++ b/theories/Autosubst_Basics.v
@@ -139,7 +139,7 @@ Tactic Notation "epose" open_constr(T) := eassert _;[refine T | idtac].
 
 Definition id {A} (x : A) := x.
 Arguments id {A} x /.
-Hint Unfold id.
+Hint Unfold id : core.
 
 Ltac fold_id :=
   repeat match goal with
@@ -177,6 +177,7 @@ Arguments funcomp {A B C} f g x /.
 
 (** ... with reversed notation *)
 
+Declare Scope subst_scope.
 Delimit Scope subst_scope with subst.
 Open Scope subst_scope.
 
@@ -194,7 +195,7 @@ Notation "s .: sigma" := (scons s sigma) (at level 55, sigma at level 56, right 
 (** A test and demonstration of the precedence rules, which effectively declare scons and
     funcomp at the same level, with scons being right associative and funcomp being left
     associative *)
-Check fun (f : var -> var) (sigma : var -> list var) =>
+Local Definition parse_test := fun (f : var -> var) (sigma : var -> list var) =>
         nil .: nil .: f >>> f >>> nil .: nil .: f >>> f >>> nil .: nil .: sigma.
 
 (* plus with different simplification behaviour *)
@@ -233,7 +234,7 @@ Context {A B : Type}.
 Implicit Types (x : A) (f : var -> A) (g : A -> B) (n m : var).
 
 Lemma scons_comp x f g : (x .: f) >>> g = (g x) .: f >>> g.
-Proof. f_ext; now destruct 0. Qed.
+Proof. f_ext; let x := fresh in intros x; now destruct x. Qed.
 
 Lemma plusSn n m : S n + m = S (n + m). reflexivity. Qed.
 Lemma plusnS n m : n + S m = S (n + m). symmetry. apply plus_n_Sm. Qed.

--- a/theories/Autosubst_Classes.v
+++ b/theories/Autosubst_Classes.v
@@ -9,6 +9,9 @@ Require Import Autosubst_Basics Autosubst_MMap.
 Definition _bind (T1 : Type) (T2 : Type) (n : nat) := T2.
 Arguments _bind / T1 T2 n.
 
+Declare Scope bind_scope.
+Open Scope bind_scope.
+
 Notation "{ 'bind' n 'of' T1 'in' T2 }" :=
   (_bind T1 T2 n) (at level 0,
    format "{ 'bind'  n  'of'  T1  'in'  T2 }") : bind_scope.
@@ -24,8 +27,6 @@ Notation "{ 'bind' T1 'in' T2 }" :=
 Notation "{ 'bind' T }" :=
   (_bind T T 1) (at level 0,
    format "{ 'bind'  T }") : bind_scope.
-
-Open Scope bind_scope.
 
 (**
   Classes for the substitution operations.

--- a/theories/Autosubst_MMap.v
+++ b/theories/Autosubst_MMap.v
@@ -147,12 +147,12 @@ Ltac derive_MMap :=
 Hint Extern 0 (MMap _ _) => derive_MMap : derive.
 
 Ltac derive_MMapLemmas := constructor;
-  [ induction 0; simpl; f_equal; trivial; apply mmap_id
-  | intros f g; induction 0; simpl; f_equal; trivial; apply mmap_comp ].
+  [ let x := fresh in intros x; induction x; simpl; f_equal; trivial; apply mmap_id
+  | let x := fresh in intros ?? x; induction x; simpl; f_equal; trivial; apply mmap_comp ].
 Hint Extern 0 (MMapLemmas _ _) => derive_MMapLemmas : derive.
 
 Ltac derive_MMapExt :=
-  intros ???; fix FIX 1; destruct 0; simpl; f_equal; auto using mmap_ext.
+  intros ???; fix FIX 1; let x := fresh in intros x; destruct x; simpl; f_equal; auto using mmap_ext.
 Hint Extern 0 (MMapExt _ _) => derive_MMapExt : derive.
 
 (* Local Variables: *)


### PR DESCRIPTION
This fixes the warnings that are shown when building with Coq 8.10.

Fixes https://github.com/coq-community/autosubst/issues/17.