### PR TITLE
avoid notation clash with ssr to make examples-ssr build again

### DIFF
--- a/.github/workflows/coq-ci.yml
+++ b/.github/workflows/coq-ci.yml
@@ -15,10 +15,12 @@ jobs:
     strategy:
       matrix:
         image:
-          - 'coqorg/coq:dev'
-          - 'coqorg/coq:8.12'
-          - 'coqorg/coq:8.11'
-          - 'coqorg/coq:8.10'
+          - 'mathcomp/mathcomp-dev:coq-dev'
+          - 'mathcomp/mathcomp:1.12.0-coq-8.13'
+          - 'mathcomp/mathcomp:1.12.0-coq-8.12'
+          - 'mathcomp/mathcomp:1.11.0-coq-8.12'
+          - 'mathcomp/mathcomp:1.10.0-coq-8.11'
+          - 'mathcomp/mathcomp:1.9.0-coq-8.10'
       fail-fast: false
     steps:
       - uses: actions/checkout@v2

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 *.vo
+*.vos
+*.vok
+*.vio
 *.glob
 *.v.d
 *.coq
@@ -7,3 +10,4 @@ doc/*
 *.aux
 Makefile.coq.conf
 .coqdeps.d
+.lia.cache

--- a/coq-autosubst-ci.opam
+++ b/coq-autosubst-ci.opam
@@ -9,6 +9,8 @@ license: "MIT"
 
 synopsis: "Autosubst (CI only)"
 
-build: [make "-j%{jobs}%" "examples-plain"]
-install: []
-depends: ["coq"]
+build: [make "-j%{jobs}%" "all"]
+depends: [
+  "coq"
+  "coq-mathcomp-ssreflect"
+]

--- a/examples/ssr/ARS.v
+++ b/examples/ssr/ARS.v
@@ -1,7 +1,6 @@
 (** * Abstract Reduction Systems
 
     Useful lemmas when working with small-step reduction relations. *)
-Require Import mathcomp.ssreflect.ssreflect.
 From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq.
 
 Set Implicit Arguments.

--- a/examples/ssr/AutosubstSsr.v
+++ b/examples/ssr/AutosubstSsr.v
@@ -5,8 +5,8 @@ Require Export Autosubst.Autosubst_Classes.
 Require Export Autosubst.Autosubst_Tactics.
 Require Export Autosubst.Autosubst_Lemmas.
 Require Export Autosubst.Autosubst_Derive.
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq.
+From mathcomp Require Import ssreflect ssrbool eqtype ssrnat seq.
+From Coq Require Import ssrfun.
 
 Set Implicit Arguments.
 Unset Strict Implicit.

--- a/examples/ssr/BetaSubstitution.v
+++ b/examples/ssr/BetaSubstitution.v
@@ -1,6 +1,5 @@
 (** * Correctness of Single Variable Substitutions *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq.
+From mathcomp Require Import ssreflect ssrbool eqtype ssrnat seq.
 Require Import Autosubst.
 
 Set Implicit Arguments.

--- a/examples/ssr/CR.v
+++ b/examples/ssr/CR.v
@@ -1,5 +1,5 @@
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq.
+From mathcomp Require Import ssreflect ssrbool eqtype ssrnat seq.
+From Coq Require Import ssrfun.
 Require Import AutosubstSsr ARS.
 
 Set Implicit Arguments.

--- a/examples/ssr/Context.v
+++ b/examples/ssr/Context.v
@@ -1,8 +1,7 @@
 (** * Context
 
     Support for dependent contexts with the right reduction behaviour. *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq.
+From mathcomp Require Import ssreflect ssrbool eqtype ssrnat seq.
 Require Import AutosubstSsr.
 
 Definition get {T} `{Ids T} (Gamma : seq T) (n : var) : T :=

--- a/examples/ssr/POPLmark.v
+++ b/examples/ssr/POPLmark.v
@@ -9,8 +9,7 @@
     and in particular does not contain well-formedness assumptions.
  *)
 
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq.
+From mathcomp Require Import ssreflect ssrbool eqtype ssrnat seq.
 Require Import AutosubstSsr Context.
 
 (** **** Syntax *)
@@ -44,7 +43,7 @@ Instance SubstLemmas_term : SubstLemmas term. derive. Qed.
 
 (** **** Subtyping *)
 
-Notation "Gamma `_ x" := (dget Gamma x).
+Notation "Gamma `_ x" := (dget Gamma x) (at level 2).
 Notation "Gamma ``_ x" := (get Gamma x) (at level 3, x at level 2,
   left associativity, format "Gamma ``_ x").
 

--- a/examples/ssr/SystemF_CBV.v
+++ b/examples/ssr/SystemF_CBV.v
@@ -1,7 +1,6 @@
 (** * Normalization of Call-By-Value System F *)
 
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq.
+From mathcomp Require Import ssreflect ssrbool eqtype ssrnat seq.
 Require Import AutosubstSsr Context.
 
 Set Implicit Arguments.
@@ -57,7 +56,7 @@ Hint Resolve eval_abs eval_tabs.
 (** **** Syntactic typing *)
 
 Definition ctx := seq type.
-Local Notation "Gamma `_ i" := (get Gamma i).
+Local Notation "Gamma `_ i" := (get Gamma i) (at level 2).
 
 Inductive has_type (Gamma : ctx) : term -> type -> Prop :=
 | ty_var (x : var) :

--- a/examples/ssr/SystemF_SN.v
+++ b/examples/ssr/SystemF_SN.v
@@ -1,7 +1,7 @@
 (** * Strong Normalization of System F *)
 
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq.
+From mathcomp Require Import ssreflect ssrbool eqtype ssrnat seq.
+From Coq Require Import ssrfun.
 Require Import AutosubstSsr ARS Context.
 
 Set Implicit Arguments.
@@ -130,7 +130,7 @@ Proof. move=> h. apply: red_compat => -[|n]/=; [exact: star1|exact: starR]. Qed.
 (** **** Syntactic typing *)
 
 Definition ctx := seq type.
-Local Notation "Gamma `_ i" := (get Gamma i).
+Local Notation "Gamma `_ i" := (get Gamma i) (at level 2).
 
 Inductive has_type (Gamma : ctx) : term -> type -> Prop :=
 | ty_var (x : var) :

--- a/examples/ssr/pred_CC_omega.v
+++ b/examples/ssr/pred_CC_omega.v
@@ -1,7 +1,8 @@
 (** * Predicative CC omega: Type Preservation and Confluence
  *)
 
-From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq.
+From mathcomp Require Import ssreflect ssrbool eqtype ssrnat seq.
+From Coq Require Import ssrfun.
 Require Import AutosubstSsr ARS Context.
 
 Set Implicit Arguments.
@@ -312,7 +313,7 @@ Proof. move=> [A' B' /sub1_subst]; eauto using sub, conv_subst. Qed.
 
 (** **** Typing *)
 
-Notation "Gamma `_ i" := (dget Gamma i).
+Notation "Gamma `_ i" := (dget Gamma i) (at level 2).
 
 Reserved Notation "[ Gamma |- ]".
 Reserved Notation "[ Gamma |- s :- A ]".

--- a/meta.yml
+++ b/meta.yml
@@ -44,18 +44,25 @@ license:
   identifier: MIT
 
 supported_coq_versions:
-  text: 8.9 or later
-  opam: '{(>= "8.9" & < "8.14~") | (= "dev")}'
+  text: 8.10 or later
+  opam: '{(>= "8.10" & < "8.14~") | (= "dev")}'
 
 tested_coq_nix_versions:
 - version_or_url: https://github.com/coq/coq-on-cachix/tarball/master
 
 tested_coq_opam_versions:
-- version: dev
-- version: '8.12'
-- version: '8.11'
-- version: '8.10'
-- version: '8.9'
+- version: 'coq-dev'
+  repo: 'mathcomp/mathcomp-dev'
+- version: '1.12.0-coq-8.13'
+  repo: 'mathcomp/mathcomp'
+- version: '1.12.0-coq-8.12'
+  repo: 'mathcomp/mathcomp'
+- version: '1.11.0-coq-8.12'
+  repo: 'mathcomp/mathcomp'
+- version: '1.10.0-coq-8.11'
+  repo: 'mathcomp/mathcomp'
+- version: '1.9.0-coq-8.10'
+  repo: 'mathcomp/mathcomp'
 
 namespace: Autosubst
 


### PR DESCRIPTION
@co-dan here is a way to preserve the SSR examples as-is by fiddling with what is imported. Only the MathComp version of `ssrfun` exports the offending notations, so we just avoid it.