### PR TITLE
bump minimal Coq version to 8.14

### DIFF
--- a/.github/workflows/docker-action.yml
+++ b/.github/workflows/docker-action.yml
@@ -1,3 +1,5 @@
+# This file was generated from `meta.yml`, please do not edit manually.
+# Follow the instructions on https://github.com/coq-community/templates to regenerate.
 name: Docker CI
 
 on:
@@ -16,10 +18,9 @@ jobs:
       matrix:
         image:
           - 'mathcomp/mathcomp-dev:coq-dev'
-          - 'mathcomp/mathcomp:1.12.0-coq-8.13'
-          - 'mathcomp/mathcomp:1.12.0-coq-8.12'
-          - 'mathcomp/mathcomp:1.11.0-coq-8.12'
-          - 'mathcomp/mathcomp:1.10.0-coq-8.11'
+          - 'mathcomp/mathcomp:1.14.0-coq-8.15'
+          - 'mathcomp/mathcomp:1.13.0-coq-8.15'
+          - 'mathcomp/mathcomp:1.12.0-coq-8.14'
       fail-fast: false
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ substitutions.
   - Ralf Jung ([**@RalfJung**](https://github.com/RalfJung))
   - Dan Frumin ([**@co-dan**](https://github.com/co-dan))
 - License: [MIT License](LICENSE)
-- Compatible Coq versions: 8.11 or later
+- Compatible Coq versions: 8.14 or later
 - Additional dependencies: none
 - Coq namespace: `Autosubst`
 - Related publication(s):

--- a/coq-autosubst.opam
+++ b/coq-autosubst.opam
@@ -23,7 +23,7 @@ substitutions."""
 build: [make "-j%{jobs}%"]
 install: [make "install"]
 depends: [
-  "coq" {(>= "8.11" & < "8.16~") | (= "dev")}
+  "coq" {(>= "8.14" & < "8.16~") | (= "dev")}
 ]
 
 tags: [

--- a/meta.yml
+++ b/meta.yml
@@ -1,4 +1,6 @@
 ---
+# When this file changes, run 'generate.sh' from
+# https://github.com/coq-community/templates to update the other files.
 fullname: Autosubst
 shortname: autosubst
 organization: coq-community
@@ -44,19 +46,17 @@ license:
   identifier: MIT
 
 supported_coq_versions:
-  text: 8.11 or later
-  opam: '{(>= "8.11" & < "8.16~") | (= "dev")}'
+  text: 8.14 or later
+  opam: '{(>= "8.14" & < "8.16~") | (= "dev")}'
 
 tested_coq_opam_versions:
 - version: 'coq-dev'
   repo: 'mathcomp/mathcomp-dev'
-- version: '1.12.0-coq-8.13'
+- version: '1.14.0-coq-8.15'
   repo: 'mathcomp/mathcomp'
-- version: '1.12.0-coq-8.12'
+- version: '1.13.0-coq-8.15'
   repo: 'mathcomp/mathcomp'
-- version: '1.11.0-coq-8.12'
-  repo: 'mathcomp/mathcomp'
-- version: '1.10.0-coq-8.11'
+- version: '1.12.0-coq-8.14'
   repo: 'mathcomp/mathcomp'
 
 namespace: Autosubst


### PR DESCRIPTION
That's a big jump, but OTOH this library hasn't changed in years so people that need to use it on old Coq can just pin an old version.

@palmskog I hope I used those templates correctly. :D  Unfortunately it looks like our GHA file needs manual adjustment to use the `coq-autosubst-ci.opam` file; after generating that changes to `coq-autosubst.opam`.