### PR TITLE
Bump for Coq 8.16

### DIFF
--- a/coq-autosubst.opam
+++ b/coq-autosubst.opam
@@ -23,7 +23,7 @@ substitutions."""
 build: [make "-j%{jobs}%"]
 install: [make "install"]
 depends: [
-  "coq" {(>= "8.14" & < "8.16~") | (= "dev")}
+  "coq" {(>= "8.14" & < "8.17~") | (= "dev")}
 ]
 
 tags: [


### PR DESCRIPTION
Following the Iris repo's opam file
https://gitlab.mpi-sws.org/iris/opam/-/blob/master/packages/coq-autosubst/coq-autosubst.dev/opam.

No CI changes yet.