### PR TITLE
Adapt to Coq PR #17084: maximal implicit arguments now added to references in defined Ltac code

### DIFF
--- a/theories/Autosubst_Derive.v
+++ b/theories/Autosubst_Derive.v
@@ -58,10 +58,10 @@ Ltac has_var s :=
         | _ =>
           match typeof s2 with
             | var => constr:(Some s2)
-            | _ => None
+          | _ => open_constr:(None)
           end
       end
-    | _ => None
+    | _ => open_constr:(None)
   end.
 
 Ltac derive_Subst :=


### PR DESCRIPTION
In anticipation of a uniformisation in coq/coq#17084 of how references with maximal implicit arguments are interpreted in Ltac code (*), this PR fixes the tactic `has_var` in `Autosubst_Derive.v` so that when `None` is returned, it returns it with its implicit argument rather than without.

This is a priori backwards compatible, so it can be merged as soon as now.

(*) Prior to coq/coq#17084, maximal implicit arguments are inserted in interactive mode but not  in non-interactive mode.