### PR TITLE
Update manual.tex: Fixed way of importing autosubst

### DIFF
--- a/manual.tex
+++ b/manual.tex
@@ -137,7 +137,7 @@
 
 We start by importing the \Autosubst library.
 \begin{lstlisting}
-Require Import Autosubst.
+From Autosubst Require Import Autosubst.
 \end{lstlisting}
 
 Using de~Bruijn Syntax in Coq, the untyped lambda calculus is usually defined as shown \autoref{fig:naive-ulc-term-def}.


### PR DESCRIPTION
Require Import Autosubst does not work.